### PR TITLE
add variable kamailio_repo_key_url

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,7 @@ dns_servers_map:
 # Kamailio
 kamailio_version: 50 # Kamailio version 5.0 . for 4.4 enter 44 and for 4.4 enter 43
 kamailio_repo: 'http://deb.kamailio.org/kamailio'
-kamailio_repo_key_url: 'http://deb.kamailio.org/kamailiodebkey.gpg'
+kamailio_repo_key_url: 'https://deb.kamailio.org/kamailiodebkey.gpg'
 kamailio_conf_dir: '/etc/kamailio' # Configuration directory
 kamailio_install_conf: False # Allow the installation of the configuration files - Could be disabled when updating
 kamailio_conf_backup_dir: '/etc/kamailio.orig' # Backup configuration directory

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,7 @@ dns_servers_map:
 # Kamailio
 kamailio_version: 50 # Kamailio version 5.0 . for 4.4 enter 44 and for 4.4 enter 43
 kamailio_repo: 'http://deb.kamailio.org/kamailio'
-kamailio_repo_keyname: 'kamailiodebkey.gpg'
+kamailio_repo_key_url: 'http://deb.kamailio.org/kamailiodebkey.gpg'
 kamailio_conf_dir: '/etc/kamailio' # Configuration directory
 kamailio_install_conf: False # Allow the installation of the configuration files - Could be disabled when updating
 kamailio_conf_backup_dir: '/etc/kamailio.orig' # Backup configuration directory

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -2,7 +2,7 @@
 
 - name: Add kamailio Repo Signing key
   apt_key:
-    url: {{ kamailio_repo }}/{{ kamailio_repo_keyname }}
+    url: "{{ kamailio_repo_key_url }}"
     state: present
 
 - name: Add kamailio apt repository (Debian 8/Jessie)


### PR DESCRIPTION
reason: there were 2 problems:
- missing quotes around the variables
- the default key URL was incorrect, there was an extra "/kamailio" in the URL